### PR TITLE
Round interval duration to nearest second to preserve sync with Zwift

### DIFF
--- a/zerg.py
+++ b/zerg.py
@@ -96,7 +96,7 @@ class ErgParser :
     def duration( self, mins ) :
         # Hard-coded for input interval times in minutes (ERG/MRC)
         # Zwift uses seconds (single in file, 5 sec rounding in GUI)
-        return 60 * mins
+        return round(60 * mins, 0)
 
     def addInterval( self, intervalType, mins, powerLow, powerHigh ) :
         # NB. duration is minutes in ERG/MRC for data, and seconds for Zwift


### PR DESCRIPTION
Zwift truncates non-integer durations (e.g. 25.6 sec) in zwo files to the nearest lower integer value (e.g 25 sec) when executing a workout. For Sufferfest workouts converted from the spreadsheet at https://docs.google.com/spreadsheets/d/1ehIbV4Kldv_k82JtadNavpeZaI7o9JGHoWghDitrM-4/edit?pref=2&pli=1#gid=1378333382, this causes Zwift to increasingly get ahead of the Sufferfest video due to the accumulation of these truncated fractions of a second. There are no actual Sufferfest intervals with non-integer durations - these appear in the spreadsheet due to calculations using rounded decimal minute values - so rounding the durations output by the convertor to the nearest second gives the correct interval length and keeps the video and Zwift in sync for the entire workout duration. See Zwift Workouts Facebook group for discussion.
